### PR TITLE
Fix binder handoff: keep all BinderContainer classes from obfuscation

### DIFF
--- a/provider/consumer-rules.pro
+++ b/provider/consumer-rules.pro
@@ -1,4 +1,13 @@
--keepnames class af.shizuku.api.BinderContainer
--keepclassmembers class af.shizuku.api.BinderContainer {
-   public static final android.os.Parcelable$Creator CREATOR;
-}
+# Cross-process Parcelable wrappers used in the server -> client binder handoff
+# (ShizukuProvider.handleSendBinder / sendBinder). These are resolved BY NAME in the
+# *client* app's classloader, so their fully qualified names AND CREATOR must survive
+# R8/obfuscation unchanged in every consumer (including the Shizuku+ manager APK, which
+# compiles this module in as a subproject).
+#
+# Keeping only af.shizuku.api.BinderContainer let R8 rename rikka.shizuku.BinderContainer
+# and moe.shizuku.api.BinderContainer; the marshalled Parcelable then carried an obfuscated
+# class name (e.g. "kd.a") that standard Shizuku/Sui clients could not resolve, throwing
+# BadParcelableException and breaking binder delivery (pingBinder() == false).
+-keep class af.shizuku.api.BinderContainer { *; }
+-keep class rikka.shizuku.BinderContainer { *; }
+-keep class moe.shizuku.api.BinderContainer { *; }


### PR DESCRIPTION
Fixes an issue that was preventing Shizuku+ from ever actually starting. The app believed it was running, however the process never started and no other apps recognized it as running. See below for Claude's more detailed explanation.

_**TODO**: Need to test locally. Have to install NDK 29 and Gradle 9.1.0 will take a bit. Pushing up as draft for visibility in case anyone else experiencing issue is able to test_


## Issue

The server sends three BinderContainer parcelables in the sendBinder handoff Bundle (af.shizuku.api, rikka.shizuku, moe.shizuku.api), but the provider's consumer ProGuard rules only kept af.shizuku.api.BinderContainer. R8 renamed the other two, so the marshalled Parcelable carried an obfuscated class name (e.g. "kd.a") that standard Shizuku clients resolve in their own classloader and reject:

  BadParcelableException: Parcelable protocol requires subclassing from
  Parcelable on class kd.a

This broke binder delivery to standard (non-Plus) clients: pingBinder() returned false even though shizuku_plus_server was running.

Keep all three cross-process BinderContainer classes fully (name + members, incl. CREATOR) so the handoff stays byte-compatible with upstream Shizuku/Sui. As consumer rules they propagate to every consumer, fixing both the Shizuku+ manager APK and third-party client apps.

## Test Plan

Verify by building the ShizukuPlus app against this branch (a debug build won't reproduce the bug — R8 doesn't run).

1. Point ShizukuPlus at this branch — in ShizukuPlus/local.properties:

```
sdk.dir=<ANDROID_SDK_PATH>
api.useLocal=true
api.dir=../ShizukuPlus-API
```
  
2. Build the minified APK (Plus flavor; gradlew.bat on Windows):
`./gradlew :manager:assembleShizukuplusRelease`

3. Install & test on device:

```
adb uninstall af.shizuku.plus.api
adb install -r <the_shizukuplus_apk_you_just_built>.apk
adb shell pm grant af.shizuku.plus.api android.permission.WRITE_SECURE_SETTINGS
```

Test that it runs correctly and other apps can use it for background installs