### PR TITLE
Fix compatibility with stock Shizuku client apps (binder delivery + v13 attach)

### DIFF
--- a/aidl/src/main/aidl/moe/shizuku/server/IShizukuApplication.aidl
+++ b/aidl/src/main/aidl/moe/shizuku/server/IShizukuApplication.aidl
@@ -1,0 +1,19 @@
+// Legacy/stock descriptor, kept so the server can call back stock Shizuku clients
+// (e.g. Obtainium) that were built against moe.shizuku.server.IShizukuApplication.
+// Transaction codes MUST match the af descriptor (and upstream Shizuku) so a single
+// wire transaction is understood by whichever stub the client registered.
+package moe.shizuku.server;
+
+interface IShizukuApplication {
+
+    oneway void bindApplication(in Bundle data) = 1;
+
+    oneway void dispatchRequestPermissionResult(int requestCode, in Bundle data) = 2;
+
+    oneway void dispatchLog(in String appName, in String packageName, in String action) = 3;
+
+    oneway void dispatchSentryEvent(in String eventJson) = 4;
+
+    // Sui only
+    void showPermissionConfirmation(int requestUid, int requestPid, in String requestPackageName, int requestCode) = 10000;
+}

--- a/provider/consumer-rules.pro
+++ b/provider/consumer-rules.pro
@@ -2,3 +2,13 @@
 -keepclassmembers class af.shizuku.api.BinderContainer {
    public static final android.os.Parcelable$Creator CREATOR;
 }
+# Wire-compat containers for stock (moe) and rikka Shizuku clients. Their class
+# names travel over the binder-delivery Bundle, so they must not be renamed by R8.
+-keepnames class moe.shizuku.api.BinderContainer
+-keepclassmembers class moe.shizuku.api.BinderContainer {
+   public static final android.os.Parcelable$Creator CREATOR;
+}
+-keepnames class rikka.shizuku.BinderContainer
+-keepclassmembers class rikka.shizuku.BinderContainer {
+   public static final android.os.Parcelable$Creator CREATOR;
+}

--- a/server-shared/src/main/java/rikka/shizuku/server/AppBinderCompat.java
+++ b/server-shared/src/main/java/rikka/shizuku/server/AppBinderCompat.java
@@ -30,14 +30,14 @@ public final class AppBinderCompat {
         try {
             application.bindApplication(reply);
         } catch (Throwable e) {
-            LOGGER.w("bindApplication via af descriptor failed");
+            LOGGER.w(e, "bindApplication via af descriptor failed");
         }
         try {
             moe.shizuku.server.IShizukuApplication.Stub
                     .asInterface(application.asBinder())
                     .bindApplication(reply);
         } catch (Throwable e) {
-            LOGGER.w("bindApplication via moe descriptor failed");
+            LOGGER.w(e, "bindApplication via moe descriptor failed");
         }
     }
 
@@ -46,14 +46,14 @@ public final class AppBinderCompat {
         try {
             application.dispatchRequestPermissionResult(requestCode, reply);
         } catch (Throwable e) {
-            LOGGER.w("dispatchRequestPermissionResult via af descriptor failed");
+            LOGGER.w(e, "dispatchRequestPermissionResult via af descriptor failed");
         }
         try {
             moe.shizuku.server.IShizukuApplication.Stub
                     .asInterface(application.asBinder())
                     .dispatchRequestPermissionResult(requestCode, reply);
         } catch (Throwable e) {
-            LOGGER.w("dispatchRequestPermissionResult via moe descriptor failed");
+            LOGGER.w(e, "dispatchRequestPermissionResult via moe descriptor failed");
         }
     }
 }

--- a/server-shared/src/main/java/rikka/shizuku/server/AppBinderCompat.java
+++ b/server-shared/src/main/java/rikka/shizuku/server/AppBinderCompat.java
@@ -1,0 +1,59 @@
+package rikka.shizuku.server;
+
+import android.os.Bundle;
+
+import rikka.shizuku.server.util.Logger;
+
+/**
+ * The IShizukuApplication callbacks (bindApplication / dispatchRequestPermissionResult)
+ * are declared {@code oneway}. Because they are fire-and-forget, a call made with the
+ * fork's {@code af.shizuku.server.IShizukuApplication} descriptor to a client that was
+ * built against the stock {@code moe.shizuku.server.IShizukuApplication} descriptor fails
+ * silently on the client (enforceInterface SecurityException) and never throws on the
+ * server, so any try/catch based fallback is dead code.
+ *
+ * To stay compatible with BOTH fork ("af") clients and stock/other ("moe") clients such
+ * as Obtainium, every callback is dispatched via both descriptors using their real
+ * AIDL-generated proxies (so marshalling is correct). A client's stub only accepts its
+ * own descriptor, so exactly one delivery succeeds and the other is ignored; the
+ * transaction codes are identical across both descriptors.
+ */
+public final class AppBinderCompat {
+
+    private static final Logger LOGGER = new Logger("AppBinderCompat");
+
+    private AppBinderCompat() {
+    }
+
+    /** Dispatch bindApplication(reply) via both the af and moe descriptors. */
+    public static void bindApplication(af.shizuku.server.IShizukuApplication application, Bundle reply) {
+        try {
+            application.bindApplication(reply);
+        } catch (Throwable e) {
+            LOGGER.w("bindApplication via af descriptor failed");
+        }
+        try {
+            moe.shizuku.server.IShizukuApplication.Stub
+                    .asInterface(application.asBinder())
+                    .bindApplication(reply);
+        } catch (Throwable e) {
+            LOGGER.w("bindApplication via moe descriptor failed");
+        }
+    }
+
+    /** Dispatch dispatchRequestPermissionResult(requestCode, reply) via both descriptors. */
+    public static void dispatchRequestPermissionResult(af.shizuku.server.IShizukuApplication application, int requestCode, Bundle reply) {
+        try {
+            application.dispatchRequestPermissionResult(requestCode, reply);
+        } catch (Throwable e) {
+            LOGGER.w("dispatchRequestPermissionResult via af descriptor failed");
+        }
+        try {
+            moe.shizuku.server.IShizukuApplication.Stub
+                    .asInterface(application.asBinder())
+                    .dispatchRequestPermissionResult(requestCode, reply);
+        } catch (Throwable e) {
+            LOGGER.w("dispatchRequestPermissionResult via moe descriptor failed");
+        }
+    }
+}

--- a/server-shared/src/main/java/rikka/shizuku/server/ClientRecord.java
+++ b/server-shared/src/main/java/rikka/shizuku/server/ClientRecord.java
@@ -30,10 +30,7 @@ public class ClientRecord {
     public void dispatchRequestPermissionResult(int requestCode, boolean allowed) {
         Bundle reply = new Bundle();
         reply.putBoolean(REQUEST_PERMISSION_REPLY_ALLOWED, allowed);
-        try {
-            client.dispatchRequestPermissionResult(requestCode, reply);
-        } catch (Throwable e) {
-            LOGGER.w(e, "dispatchRequestPermissionResult failed for client (uid=%d, pid=%d, package=%s)", uid, pid, packageName);
-        }
+        // Dispatch via both af and moe descriptors so stock clients (e.g. Obtainium) receive it.
+        AppBinderCompat.dispatchRequestPermissionResult(client, requestCode, reply);
     }
 }

--- a/server-shared/src/main/java/rikka/shizuku/server/Service.java
+++ b/server-shared/src/main/java/rikka/shizuku/server/Service.java
@@ -447,6 +447,18 @@ public abstract class Service<
                         attachApplication(IShizukuApplication.Stub.asInterface(binder), args);
                         reply.writeNoException();
                         return true;
+                    case 17: { // attachApplication v13+
+                        // Must be handled here like the other legacy-token methods: the interface
+                        // token was already consumed above, so letting this fall through to
+                        // super.onTransact re-reads from the wrong parcel position and the attach
+                        // fails ("not an attached client"), breaking getUid/getVersion/bindApplication
+                        // for every v13 client (including the manager itself).
+                        IBinder appBinder = data.readStrongBinder();
+                        Bundle attachArgs = data.readInt() != 0 ? Bundle.CREATOR.createFromParcel(data) : null;
+                        attachApplication(IShizukuApplication.Stub.asInterface(appBinder), attachArgs);
+                        reply.writeNoException();
+                        return true;
+                    }
                 }
             } else {
                 // Shizuku+ specific handling for code 14 and 17


### PR DESCRIPTION
### Summary
Apps built against the standard Shizuku API (e.g. Obtainium's "Install via Shizuku") can't use Shizuku+ — the server starts and the manager shows running, but clients report "Shizuku service not running". This fixes the three server/API-side causes, all stemming from the `moe.shizuku` → `af.shizuku` rename.

### Root causes & fixes
1. **Binder container obfuscated.** R8 renames the wire class `moe.shizuku.api.BinderContainer` (and the `rikka.shizuku` one) because only `af.shizuku.api.BinderContainer` is kept. Stock clients then hit `ClassNotFoundException` unmarshalling the binder-delivery Bundle. → keep all three names in `consumer-rules.pro`.
2. **`IShizukuApplication` callbacks are `oneway` and only speak the `af` descriptor.** A wrong-descriptor oneway call fails silently on the client and never throws, so the existing catch-based `moe` fallback is dead code — stock clients never receive `bindApplication`/permission results. → `AppBinderCompat` dispatches both callbacks via **both** descriptors using their real AIDL proxies (adds `moe/shizuku/server/IShizukuApplication.aidl`).
3. **`attachApplication` v13 (transaction 17) isn't handled** in `Service.onTransact`'s legacy-token path (it's only in a branch that's unreachable because `isLegacy`/`isNew` test the same descriptor). It falls through to `super.onTransact`, which re-reads from the wrong parcel position after the token was consumed, so the attach fails ("not an attached client") for **every** v13 client — including the manager itself. → handle `case 17` alongside the other legacy methods.

### Testing
Built and verified on a Samsung Galaxy Z Fold 6 (One UI 8.5 / Android 16): Obtainium's Shizuku install path works, and the manager attaches cleanly (no more "not an attached client").

Server-side half of thejaustin/ShizukuPlus#306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
